### PR TITLE
FIX: okta url for project not using okta

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,5 +2,5 @@ PORT=8000
 DS_API_URL=http://localhost:8002
 DS_API_TOKEN=SUPERSECRET
 DATABASE_URL=postgres://docker:docker@127.0.0.1:5400/api-dev
-OKTA_URL_ISSUER=https://example.okta.com/oauth2/default
-OKTA_CLIENT_ID=example
+OKTA_URL_ISSUER=https://auth.lambdalabs.dev/oauth2/default
+OKTA_CLIENT_ID=0oalwp37fU2aV9UEG4x6


### PR DESCRIPTION
OKTA_URL_ISSUER url changed to Lambda Labs sepcific, along with CLIENT_ID